### PR TITLE
Syntax fixes

### DIFF
--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -44,6 +44,7 @@
      '("mexpr"
        "include"
        "never"
+       "error"
        ))
 
 (setq mcore-keywords-regexp (regexp-opt mcore-keywords 'symbols))

--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -69,13 +69,15 @@
 (defvar mcore-mode-syntax-table nil "Syntax table for `mcore-mode'.")
 
 (setq mcore-mode-syntax-table
-     (let ((table (make-syntax-table)))
-       ;; Inline comment “// ...”
-       ;; Inline comment “-- ...”
-       (modify-syntax-entry ?/ ". 12a" table)
-       (modify-syntax-entry ?- "_ 123" table)
-       (modify-syntax-entry ?\n ">" table)
-       table))
+      (let ((table (make-syntax-table)))
+        ;; Inline comment “-- ...”
+        (modify-syntax-entry ?- ". 12" table)
+        ;; C-style comments “// ...” and “/* ... */”
+        (modify-syntax-entry ?/ ". 124" table)
+        (modify-syntax-entry ?* ". 23b" table)
+        (modify-syntax-entry ?\n ">" table)
+        (modify-syntax-entry ?' "\"" table)
+        table))
 
 ;;;;;;;;;;;;;;
 ;; prettify ;;

--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -69,13 +69,13 @@
 (defvar mcore-mode-syntax-table nil "Syntax table for `mcore-mode'.")
 
 (setq mcore-mode-syntax-table
-     (let ( (synTable (make-syntax-table)))
+     (let ((table (make-syntax-table)))
        ;; Inline comment “// ...”
        ;; Inline comment “-- ...”
-       (modify-syntax-entry ?/ ". 12a" synTable)
-       (modify-syntax-entry ?- "_ 123" synTable)
-       (modify-syntax-entry ?\n ">" synTable)
-       synTable))
+       (modify-syntax-entry ?/ ". 12a" table)
+       (modify-syntax-entry ?- "_ 123" table)
+       (modify-syntax-entry ?\n ">" table)
+       table))
 
 ;;;;;;;;;;;;;;
 ;; prettify ;;


### PR DESCRIPTION
This is a somewhat opinionated PR. I changed `error` to be highlighted by the warning font face, since I feel that it alters the control flow of a program so much that it should visually stand out.

I also modified the syntax table to provide syntax highlighting of characters and  c-style block comments. i don't remember if we came to a conclusion regarding the comment style, but as of now all `--...`, `//...` and `/*...*/` are considered comments in boot.

Note that `-/` and `/-` are incorrectly marked as comment starts. This was true before this PR as well.

References:
https://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-Class-Table.html#Syntax-Class-Table
https://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-Flags.html#Syntax-Flags
