### PR TITLE
Set line comment.

### DIFF
--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -125,7 +125,8 @@
 (define-derived-mode mcore-mode prog-mode
  (setq font-lock-defaults '(mcore-font-lock-keywords))
  (setq mode-name "mcore")
- )
+ (setq-local comment-start "--")
+ (setq-local comment-end ""))
 
 ;; Open “*.mcore” in mcore-mode
 (add-to-list 'auto-mode-alist '("\\.mc\\'" . mcore-mode))

--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -83,7 +83,7 @@
 ;;;;;;;;;;;;;;
 
 (defvar mcore-prettify-symbols-alist
-  '(("lam" . 955))
+  '(("lam" . 955))                      ; λ
   "List of syntax to prettify for `mcore-mode'.")
 
 (if (boundp 'prettify-symbols-alist)


### PR DESCRIPTION
Since we have decided upon a comment syntax this PR sets the line comment syntax for `mcore-mode` so that you don't have to specify this manually every session. I also added a comment showing the unicode equivalent character at the prettify symbols list definition for clarity. 