### PR TITLE
Add tree-sitter syntax highlighting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ To use the mode, add the following to your `init.el` file:
 
 (or run `M-x eval-buffer` in the file defining the mode)
 
+## Tree-sitter support
+
+`miking-emacs` supports parser-based syntax highlighting based on the new tree-sitter support in Emacs 29.
+To utilize this functionality, first make sure your Emacs version is at least 29.0.60 and that `(treesit-available-p)` returns `t`.
+Then, build the `tree-sitter-miking` grammar by following the instructions [here](https://git.sr.ht/~aathn/tree-sitter-miking).
+Move the resulting `libtree-sitter-mlang.so` file to `$HOME/.emacs.d/tree-sitter/`, and you're good to go!
+The advanced syntax highlighting will be enabled automatically, and you can control the level of fontification using `treesit-font-lock-level`.
+For instance,
+
+```elisp
+(setq-default treesit-font-lock-level 3)
+```
+
+will set a moderate level of fontification (values between 1-4 are possible).
+
+You can also explore the syntax tree of an MCore file using the `treesit-explore-mode` command, or get a mode line indication of your position in the tree using `treesit-inspect-mode`.
+
 ## Companion Packages
 
 - [Ctags support](https://github.com/miking-lang/miking-ctags)


### PR DESCRIPTION
This PR adds parser-based syntax highlighting using the new tree-sitter support in Emacs 29.  The mode automatically switches to tree-sitter-based highlighting when it is available, falling back to the old version otherwise.

The PR also rearranges some code, and adds some missing keywords.

The README is updated with instructions for enabling the new feature; installation is easy provided that one has compiled a version of Emacs with tree-sitter support.  The mode uses the MLang tree-sitter grammar from [my repository](https://git.sr.ht/~aathn/tree-sitter-miking), which we may want to consider adding to the miking group on Github as well.  

In more detail, the tree-sitter library enables Emacs to parse code files incrementally and provide syntax highlighting based on the actual syntax tree of the file, rather than simply highlighting select keywords or regexes.  This means we can easily highlight e.g. the function in an application or the name and parameters in a declaration.

The two images below give a peek at how the highlighting looks before and after.

![Without tree-sitter](https://aathn.org/regex-syntax.png)
![With tree-sitter](https://aathn.org/treesit-syntax.png)

One can control the level of fontification using the `treesit-font-lock-level` variable (which is an integer in the range `[1,4]`); the screenshot above uses level 3.

I also want to recommend the excellent `treesit-explore-mode` which can be used to explore a syntax tree interactively (although this is not directly connected to the PR).
