### PR TITLE
Extended features and code refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,28 @@ To use the mode, add the following to your `init.el` file:
 
 ## Tree-sitter support
 
-`miking-emacs` supports parser-based syntax highlighting based on the new tree-sitter support in Emacs 29.
+`miking-emacs` supports parser-based syntax highlighting and other features using the new tree-sitter support in Emacs 29.
 To utilize this functionality, first make sure your Emacs version is at least 29.0.60 and that `(treesit-available-p)` returns `t`.
 Then, build the `tree-sitter-miking` grammar by following the instructions [here](https://git.sr.ht/~aathn/tree-sitter-miking).
 Move the resulting `libtree-sitter-mlang.so` file to `$HOME/.emacs.d/tree-sitter/`, and you're good to go!
-The advanced syntax highlighting will be enabled automatically, and you can control the level of fontification using `treesit-font-lock-level`.
+
+In Emacs, enable `mcore-ts-mode` instead of `mcore-mode` to get the extended functionality.
+You can make this automatic by extending `auto-mode-alist` like so.
+
+```elisp
+;; Open “*.mc” in mcore-ts-mode
+(add-to-list 'auto-mode-alist '("\\.mc\\'" . mcore-ts-mode))
+```
+
+Opening a `.mc`-file, you should now see function names being highlighted.
+You can control the level of fontification using `treesit-font-lock-level`.
 For instance,
 
 ```elisp
 (setq-default treesit-font-lock-level 3)
 ```
 
-will set a moderate level of fontification (values between 1-4 are possible).
+will set a moderate level of fontification (3 is default; values in the range 1-4 are possible).
 
 You can also explore the syntax tree of an MCore file using the `treesit-explore-mode` command, or get a mode line indication of your position in the tree using `treesit-inspect-mode`.
 

--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -315,23 +315,30 @@
 ;; mode definition ;;
 ;;;;;;;;;;;;;;;;;;;;;
 
+;;;###autoload
 (define-derived-mode mcore-mode prog-mode "mcore"
-  "Major mode for editing Miking MCore code."
+  "Major mode for editing MCore files."
   (setq-local font-lock-defaults '(mcore-font-lock-keywords))
   (setq-local comment-start "--")
   (setq-local comment-end "")
-  (setq-local imenu-generic-expression mcore--imenu-generic-expression)
+  (setq-local imenu-generic-expression mcore--imenu-generic-expression))
 
-  (when (and (fboundp 'treesit-ready-p)
-             (treesit-ready-p 'mlang))
-    (setq-local treesit-font-lock-settings mcore--treesit-font-lock-settings)
-    (setq-local treesit-font-lock-feature-list
-                '((comment punctuation)
-                  (keyword type builtin constant)
-                  (function-name variable-name)
-                  (pattern-name label-name)))
-    (setq-local imenu-create-index-function #'mcore--treesit-imenu-index-function)
-    (treesit-major-mode-setup)))
+;;;###autoload
+(define-derived-mode mcore-ts-mode prog-mode "mcore"
+  "Major mode for editing MCore files, powered by tree-sitter."
+  (unless (and (fboundp 'treesit-ready-p)
+               (treesit-ready-p 'mlang))
+    (error "Tree-sitter for MLang isn't available"))
+  (setq-local treesit-font-lock-settings mcore--treesit-font-lock-settings)
+  (setq-local treesit-font-lock-feature-list
+              '((comment punctuation)
+                (keyword type builtin constant)
+                (function-name variable-name)
+                (pattern-name label-name)))
+  (setq-local comment-start "--")
+  (setq-local comment-end "")
+  (setq-local imenu-create-index-function #'mcore--treesit-imenu-index-function)
+  (treesit-major-mode-setup))
 
 ;; Open “*.mc” in mcore-mode
 (add-to-list 'auto-mode-alist '("\\.mc\\'" . mcore-mode))

--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -163,9 +163,12 @@
         ))
 
      :language 'mlang
-     :feature 'extra-names
-     '((name_pat) @font-lock-variable-name-face
-       (label_ident) @font-lock-property-face
+     :feature 'pattern-name
+     '((name_pat) @font-lock-variable-name-face)
+
+     :language 'mlang
+     :feature 'label-name
+     '((label_ident) @font-lock-property-face
        (proj_expr "." :anchor (uint) @font-lock-property-face))
 
      :language 'mlang
@@ -263,7 +266,7 @@
                 '((comment punctuation)
                   (keyword type builtin constant)
                   (function-name variable-name)
-                  (extra-names)))
+                  (pattern-name label-name)))
     (treesit-major-mode-setup)))
 
 ;; Open “*.mc” in mcore-mode

--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -1,129 +1,130 @@
-;;; mcore-mode.el
+;;; mcore-mode.el -*- lexical-binding: t -*-
+
+(require 'pcase)
+(require 'seq)
+(require 'treesit nil 'noerror)
 
 ;;;;;;;;;;;;;;;;;;
 ;; Highlighting ;;
 ;;;;;;;;;;;;;;;;;;
 
-(setq mcore-builtin-types
-      '("()"
-        "Int"
-        "Float"
-        "Bool"
-        "Char"
-        "String"
-        "Tensor"
-        ))
+;; Please keep these lists sorted
+(defvar mcore--builtin-types
+  '("()"
+    "Int"
+    "Float"
+    "Bool"
+    "Char"
+    "String"
+    "Tensor"
+    ))
 
-(setq mcore-special-types
-      '("Unknown"))
+(defvar mcore--special-types
+  '("Unknown"))
 
-;; Please keep this list sorted
-(setq mcore-base-keywords
-      '(
-        "all"
-        "case"
-        "con"
-        "else"
-        "end"
-        "external"
-        "if"
-        "in"
-        "lam"
-        "lang"
-        "let"
-        "match"
-        "recursive"
-        "sem"
-        "switch"
-        "syn"
-        "then"
-        "type"
-        "use"
-        "using"
-        "utest"
-        "with"
-        ))
+(defvar mcore--base-keywords
+  '(
+    "all"
+    "case"
+    "con"
+    "else"
+    "end"
+    "external"
+    "if"
+    "in"
+    "lam"
+    "lang"
+    "let"
+    "match"
+    "recursive"
+    "sem"
+    "switch"
+    "syn"
+    "then"
+    "type"
+    "use"
+    "using"
+    "utest"
+    "with"
+    ))
 
-(setq mcore-special-keywords
-      '(
-        "include"
-        "mexpr"
-        ))
+(defvar mcore--special-keywords
+  '(
+    "include"
+    "mexpr"
+    ))
 
-(setq mcore-extra-keywords
-      '(
-        "hole"
-        "independent"
-        "accelerate"
-        "loop"
-        ))
+(defvar mcore--extra-keywords
+  '(
+    "hole"
+    "independent"
+    "accelerate"
+    "loop"
+    ))
 
-(setq mcore-constants
-      '(
-        "false"
-        "true"
-        "()"
-        ))
+(defvar mcore--constants
+  '(
+    "false"
+    "true"
+    "()"
+    ))
 
-(setq mcore-special-constants
-      '(
-        "never"
-        ))
+(defvar mcore--special-constants
+  '(
+    "never"
+    ))
 
-(setq mcore-builtin-functions
-      '(
-        ;; More could be added
-        "error"
-        ))
+(defvar mcore--builtin-functions
+  '(
+    ;; NOTE(aathn, 2022-12-15): More builtin functions can be added here
+    "error"
+    ))
 
-(setq mcore-keywords
-      (append
-       mcore-base-keywords
-       mcore-extra-keywords))
+(defvar mcore-font-lock-keywords
+  (let* ((mcore-keywords
+          (append
+           mcore--base-keywords
+           mcore--extra-keywords))
+         (mcore-warning
+          (append
+           mcore--special-keywords
+           mcore--special-constants
+           mcore--special-types))
 
-(setq mcore-warning
-      (append
-       mcore-special-keywords
-       mcore-special-constants
-       mcore-special-types))
+         (mcore-keywords-regexp (regexp-opt mcore-keywords 'symbols))
+         (mcore-builtin-functions-regexp (regexp-opt mcore--builtin-functions 'symbols))
+         (mcore-constants-regexp (regexp-opt mcore--constants 'symbols))
+         (mcore-builtin-types-regexp (regexp-opt mcore--builtin-types 'symbols))
+         (mcore-warning-regexp (regexp-opt mcore-warning 'symbols))
 
-(setq mcore-keywords-regexp (regexp-opt mcore-keywords 'symbols))
-(setq mcore-builtin-functions-regexp (regexp-opt mcore-builtin-functions 'symbols))
-(setq mcore-constants-regexp (regexp-opt mcore-constants 'symbols))
-(setq mcore-builtin-types-regexp (regexp-opt mcore-builtin-types 'symbols))
-(setq mcore-warning-regexp (regexp-opt mcore-warning 'symbols))
+         (mcore-types-regexp "\\_<[[:upper:]][[:word:]]*\\_>"))
+    `(
+      (,mcore-keywords-regexp   . font-lock-keyword-face)
+      (,mcore-constants-regexp  . font-lock-constant-face)
+      (,mcore-builtin-types-regexp . font-lock-type-face)
+      (,mcore-builtin-functions-regexp  . font-lock-builtin-face)
+      (,mcore-types-regexp      . font-lock-type-face)
+      (,mcore-warning-regexp     . font-lock-warning-face)
+      ))
+  "List of font lock keyword specifications to use in `mcore-mode'.")
 
-(setq mcore-types-regexp "\\_<[[:upper:]][[:word:]]*\\_>")
-
-(setq mcore-font-lock-keywords
-     `(
-       (,mcore-keywords-regexp   . font-lock-keyword-face)
-       (,mcore-constants-regexp  . font-lock-constant-face)
-       (,mcore-builtin-types-regexp . font-lock-type-face)
-       (,mcore-builtin-functions-regexp  . font-lock-builtin-face)
-       (,mcore-types-regexp      . font-lock-type-face)
-       (,mcore-warning-regexp     . font-lock-warning-face)
-       )
-     )
-
-(defvar mcore-mode-syntax-table nil "Syntax table for `mcore-mode'.")
-
-(setq mcore-mode-syntax-table
-      (let ((table (make-syntax-table)))
-        ;; Inline comment "-- ..."
-        ;; Block comment "/- ... -/"
-        (modify-syntax-entry ?- ". 123" table)
-        (modify-syntax-entry ?/ ". 14cn" table)
-        (modify-syntax-entry ?\n "> " table)
-        (modify-syntax-entry ?' "\"" table)
-        table))
+(defvar mcore-mode-syntax-table
+  (let ((table (make-syntax-table)))
+    ;; Inline comment "-- ..."
+    ;; Block comment "/- ... -/"
+    (modify-syntax-entry ?- ". 123" table)
+    (modify-syntax-entry ?/ ". 14cn" table)
+    (modify-syntax-entry ?\n "> " table)
+    (modify-syntax-entry ?' "\"" table)
+    table)
+  "Syntax table for `mcore-mode'.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tree-sitter support ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defvar mcore--treesit-font-lock-settings
-  (when (fboundp 'treesit-font-lock-rules)
+  (when (featurep 'treesit)
     (treesit-font-lock-rules
      :language 'mlang
      :feature 'type
@@ -158,7 +159,7 @@
      `((
         (var_ident) @font-lock-builtin-face
         (:match
-         ,(concat "^\\(" (string-join mcore-builtin-functions "\\|") "\\)$")
+         ,(concat "^\\(" (string-join mcore--builtin-functions "\\|") "\\)$")
          @font-lock-builtin-face)
         ))
 
@@ -188,12 +189,12 @@
 
      :language 'mlang
      :feature 'keyword
-     `([,@mcore-base-keywords] @font-lock-keyword-face
-       [,@mcore-special-keywords] @font-lock-warning-face
+     `([,@mcore--base-keywords] @font-lock-keyword-face
+       [,@mcore--special-keywords] @font-lock-warning-face
        (
         (var_ident) @font-lock-keyword-face
         (:match
-         ,(concat "^\\(" (string-join mcore-extra-keywords "\\|") "\\)$")
+         ,(concat "^\\(" (string-join mcore--extra-keywords "\\|") "\\)$")
          @font-lock-keyword-face)
         ))
 
@@ -208,46 +209,36 @@
   "Tree-sitter font-lock settings for `mcore-mode'.")
 
 ;;;;;;;;;;;;;;
-;; prettify ;;
+;; Prettify ;;
 ;;;;;;;;;;;;;;
 
 (defvar mcore-prettify-symbols-alist
-  '(("lam" . 955)                      ; λ
-    ("all" . 8704)                     ; ∀
-    ("->" . 8594))                     ; →
+  '(("lam" . ?λ)
+    ("all" . ?∀)
+    ("->" . ?→))
   "List of syntax to prettify for `mcore-mode'.")
 
-(if (boundp 'prettify-symbols-alist)
-    (add-hook 'mcore-mode-hook
-              (lambda ()
-                (mapc (lambda (pair) (push pair prettify-symbols-alist))
-                      mcore-prettify-symbols-alist))))
-
 ;;;;;;;;;;;;;;;;;
-;; compilation ;;
+;; Compilation ;;
 ;;;;;;;;;;;;;;;;;
 
-(add-hook 'mcore-mode-hook
-          (lambda ()
-            ;; Set default compile command
-            (progn
-              (set (make-local-variable 'compile-command)
-                   (concat "mi " (buffer-name)))
-              ;; Get location of standard library from environment
-              (let ((path
-                     (replace-regexp-in-string
-                      "[[:space:]\n]*$" ""
-                      (shell-command-to-string "$SHELL -l -c 'echo $MCORE_STDLIB'"))))
-                (if (> (length path) 0)
-                  (set (make-local-variable 'compilation-environment)
-                       (list (concat "MCORE_STDLIB=" path))))))))
+(defun mcore--setup-compile ()
+  ;; Set default compile command
+  (set (make-local-variable 'compile-command)
+       (concat "mi " (buffer-name)))
+  ;; Get location of standard library from environment
+  (let ((path
+         (replace-regexp-in-string
+          "[[:space:]\n]*$" ""
+          (shell-command-to-string "$SHELL -l -c 'echo $MCORE_STDLIB'"))))
+    (if (> (length path) 0)
+        (set (make-local-variable 'compilation-environment)
+             (list (concat "MCORE_STDLIB=" path))))))
 
-(setq mcore-error-regexp
-      '(mcore "\"\\(.+\\)\" \\([0-9]+\\):\\([0-9]+\\)" 1 2 3))
-(add-hook 'compilation-mode-hook
-          (lambda ()
-            (add-to-list 'compilation-error-regexp-alist-alist mcore-error-regexp)
-            (add-to-list 'compilation-error-regexp-alist 'mcore)))
+(let ((mcore-error-regexp
+       '(mcore "\"\\(.+\\)\" \\([0-9]+\\):\\([0-9]+\\)" 1 2 3)))
+  (add-to-list 'compilation-error-regexp-alist-alist mcore-error-regexp)
+  (add-to-list 'compilation-error-regexp-alist 'mcore))
 
 ;;;;;;;;;;;
 ;; Imenu ;;
@@ -264,6 +255,8 @@
   (seq-filter
    #'cdr
    (list
+    ;; Make a menu Langs, with a submenu for each language fragment in the file
+    ;; containing the sems, syns and types of that fragment.
     `("Langs"
       .
       ,(mapcar
@@ -283,6 +276,8 @@
                      (syn_decl (type_ident) @match))))))))
         (treesit-query-capture
          'mlang '((mlang) @match))))
+    ;; Make a menu Types, with a submenu for each top-level type in the file
+    ;; containing the constructors of that type.
     `("Types"
       .
       ,(mapcar
@@ -303,6 +298,7 @@
                     `(,(treesit-node-text node t) . ,(treesit-node-start node))))))))
         (treesit-query-capture
          'mlang '((type_bind (type_ident) @match)))))
+    ;; Make a menu Lets containing all top-level (MLang) lets in the file.
     `("Lets"
       .
       ,(mapcar
@@ -312,21 +308,28 @@
          'mlang '((source_file (let_bind (var_ident) @match)))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;
-;; mode definition ;;
+;; Mode definition ;;
 ;;;;;;;;;;;;;;;;;;;;;
 
 ;;;###autoload
-(define-derived-mode mcore-mode prog-mode "mcore"
-  "Major mode for editing MCore files."
-  (setq-local font-lock-defaults '(mcore-font-lock-keywords))
+(define-derived-mode mcore-base-mode prog-mode "mcore"
+  "Generic mode for editing MCore files."
   (setq-local comment-start "--")
   (setq-local comment-end "")
+  (setq-local prettify-symbols-alist mcore-prettify-symbols-alist)
+  (mcore--setup-compile))
+
+;;;###autoload
+(define-derived-mode mcore-mode mcore-base-mode "mcore"
+  "Major mode for editing MCore files."
+  (setq-local font-lock-defaults '(mcore-font-lock-keywords))
   (setq-local imenu-generic-expression mcore--imenu-generic-expression))
 
 ;;;###autoload
-(define-derived-mode mcore-ts-mode prog-mode "mcore"
+(define-derived-mode mcore-ts-mode mcore-base-mode "mcore"
   "Major mode for editing MCore files, powered by tree-sitter."
-  (unless (and (fboundp 'treesit-ready-p)
+  :syntax-table mcore-mode-syntax-table
+  (unless (and (featurep 'treesit)
                (treesit-ready-p 'mlang))
     (error "Tree-sitter for MLang isn't available"))
   (setq-local treesit-font-lock-settings mcore--treesit-font-lock-settings)
@@ -335,8 +338,6 @@
                 (keyword type builtin constant)
                 (function-name variable-name)
                 (pattern-name label-name)))
-  (setq-local comment-start "--")
-  (setq-local comment-end "")
   (setq-local imenu-create-index-function #'mcore--treesit-imenu-index-function)
   (treesit-major-mode-setup))
 

--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -119,10 +119,6 @@
     table)
   "Syntax table for `mcore-mode'.")
 
-;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Tree-sitter support ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;
-
 (defvar mcore--treesit-font-lock-settings
   (when (featurep 'treesit)
     (treesit-font-lock-rules
@@ -206,7 +202,7 @@
      :language 'mlang
      :feature 'comment
      '([(line_comment) (block_comment)] @font-lock-comment-face)))
-  "Tree-sitter font-lock settings for `mcore-mode'.")
+  "Tree-sitter font-lock settings for `mcore-ts-mode'.")
 
 ;;;;;;;;;;;;;;
 ;; Prettify ;;
@@ -329,17 +325,20 @@
 (define-derived-mode mcore-ts-mode mcore-base-mode "mcore"
   "Major mode for editing MCore files, powered by tree-sitter."
   :syntax-table mcore-mode-syntax-table
-  (unless (and (featurep 'treesit)
-               (treesit-ready-p 'mlang))
-    (error "Tree-sitter for MLang isn't available"))
-  (setq-local treesit-font-lock-settings mcore--treesit-font-lock-settings)
-  (setq-local treesit-font-lock-feature-list
-              '((comment punctuation)
-                (keyword type builtin constant)
-                (function-name variable-name)
-                (pattern-name label-name)))
-  (setq-local imenu-create-index-function #'mcore--treesit-imenu-index-function)
-  (treesit-major-mode-setup))
+  (when (and (featurep 'treesit)
+             (treesit-ready-p 'mlang))
+
+    ;; Highlighting
+    (setq-local treesit-font-lock-settings mcore--treesit-font-lock-settings)
+    (setq-local treesit-font-lock-feature-list
+                '((comment punctuation)
+                  (keyword type builtin constant)
+                  (function-name variable-name)
+                  (pattern-name label-name)))
+
+    (setq-local imenu-create-index-function #'mcore--treesit-imenu-index-function)
+    (setq-local treesit-defun-type-regexp "sem_decl\\|let_bind")
+    (treesit-major-mode-setup)))
 
 ;; Open “*.mc” in mcore-mode
 (add-to-list 'auto-mode-alist '("\\.mc\\'" . mcore-mode))


### PR DESCRIPTION
This pull request makes the following changes.
- Separate tree-sitter support into its own mode, `mcore-ts-mode`.  A user who wants this mode by default can add an entry to `auto-mode-alist`, the README is updated with instructions for doing so.  This change makes the mode more consistent with other tree-sitter-based language modes in Emacs 29.
- Add support for `imenu`, letting the user list definitions in a file.  Without tree-sitter enabled, a simple regex-based search is used, whereas with tree-sitter a more advanced logic is employed.  In the latter mode, `imenu` presents syntax-aware submenus for each language fragment and type in the file, in addition to listing top-level let-bindings.
- Add support for automatic indentation in `mcore-ts-mode`.
- Set `treesit-defun-type-regexp` in `mcore-ts-mode`, enabling a tree-sitter-based `beginning-of-defun` function.
- Refactor the code to use lexical binding, `defvar` and `let`, avoiding the use of `setq`.  Also make various smaller changes to match the style of other major modes.