### PR TITLE
Add dependency on compile package

### DIFF
--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -3,6 +3,7 @@
 (require 'pcase)
 (require 'seq)
 (require 'treesit nil 'noerror)
+(require 'compile)
 
 ;;;;;;;;;;;;;;;;;;
 ;; Highlighting ;;


### PR DESCRIPTION
Without it, I get an error that the variable `compilation-error-regexp-alist-alist` is not defined.