### PR TITLE
Add missing require

### DIFF
--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -2,6 +2,7 @@
 
 (require 'pcase)
 (require 'seq)
+(require 'compile)
 (require 'treesit nil 'noerror)
 
 ;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
`compilation-error-regexp-alist-alist` is undefined if we do not require `compile.el`