### PR TITLE
Tweak compilation

### DIFF
--- a/mcore-mode.el
+++ b/mcore-mode.el
@@ -287,7 +287,7 @@
         (ansi-color-apply-on-region compilation-filter-start (point-max))))
     (if (boundp 'ansi-color-compilation-filter) ; for emacs version >= 28.1
         (add-hook 'compilation-filter-hook 'ansi-color-compilation-filter)
-        (add-hook 'compilation-filter-hook 'my-colorize-compilation-buffer)))
+      (add-hook 'compilation-filter-hook 'my-colorize-compilation-buffer)))
 
   "Setup error matching and error display in compilation buffers for `mcore-mode'")
 

--- a/miking-syn-mode.el
+++ b/miking-syn-mode.el
@@ -22,6 +22,8 @@
 ;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 (require 'compile)
+(require 'mcore-mode)
+
 ;;;;;;;;;;;;;;;;;;
 ;; Highlighting ;;
 ;;;;;;;;;;;;;;;;;;
@@ -78,28 +80,12 @@
 ;; compilation ;;
 ;;;;;;;;;;;;;;;;;
 
-(add-hook 'miking-syn-mode-hook
-          (lambda ()
-            ;; Set default compile command
-            (progn
-              (set (make-local-variable 'compile-command)
-                   (concat "mi syn " (buffer-name) " " (file-name-sans-extension (buffer-name)) "_gen.mc")))))
-
-(setq miking-syn-error-regexp
-      '(miking-syn "\"\\(.+\\)\" \\([0-9]+\\):\\([0-9]+\\)" 1 2 3))
-(add-hook 'compilation-mode-hook
-          (lambda ()
-            (add-to-list 'compilation-error-regexp-alist-alist miking-syn-error-regexp)
-            (add-to-list 'compilation-error-regexp-alist 'miking-syn)))
-
-;; Display ansi-colors
-; from https://stackoverflow.com/questions/13397737/ansi-coloring-in-compilation-mode
-(require 'ansi-color)
-(defun colorize-compilation-buffer ()
-  (toggle-read-only)
-  (ansi-color-apply-on-region compilation-filter-start (point))
-  (toggle-read-only))
-(add-hook 'compilation-filter-hook 'colorize-compilation-buffer)
+(defun miking-syn--setup-compile ()
+    (mcore-setup-error-regexp)            ; We have the same error format
+    ;; Set default compile command
+    (set (make-local-variable 'compile-command)
+        (concat "mi syn " (buffer-name) " "
+            (file-name-sans-extension (buffer-name)) "_gen.mc")))
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; mode definition ;;
@@ -107,11 +93,11 @@
 
 ;;;###autoload
 (define-derived-mode miking-syn-mode prog-mode "miking-syn"
-  "Major mode for editing Miking miking-syn code."
-  (setq-local font-lock-defaults '(miking-syn-font-lock-keywords))
-  (setq-local comment-start "--")
-  (setq-local comment-end "")
-)
+    "Major mode for editing Miking miking-syn code."
+    (setq-local font-lock-defaults '(miking-syn-font-lock-keywords))
+    (setq-local comment-start "--")
+    (setq-local comment-end "")
+    (miking-syn--setup-compile))
 
 ;; Open “*.syn” in miking-syn-mode
 ;;;###autoload

--- a/miking-syn-mode.el
+++ b/miking-syn-mode.el
@@ -1,4 +1,4 @@
-;;; miking-syn-mode.el
+;;; miking-syn-mode.el -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2022 Elias Castegren <elias.castegren@gmail.com>
 ;;
@@ -21,12 +21,13 @@
 ;; OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 ;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+(require 'compile)
 ;;;;;;;;;;;;;;;;;;
 ;; Highlighting ;;
 ;;;;;;;;;;;;;;;;;;
 
 ;; Please keep this list sorted
-(setq miking-syn-keywords
+(defvar miking-syn--keywords
       '(
         "empty"
         "except"
@@ -42,7 +43,7 @@
         "type"
         ))
 
-(setq miking-syn-operators
+(defvar miking-syn--operators
       '(
         "+"
         "?"
@@ -50,29 +51,28 @@
         "|"
         ))
 
-(setq miking-syn-types-regexp "\\_<[[:upper:]][[:word:]]*\\_>")
+(defvar miking-syn--types-regexp "\\_<[[:upper:]][[:word:]]*\\_>")
+(defvar miking-syn--keywords-regexp (regexp-opt miking-syn--keywords 'symbols))
+(defvar miking-syn--operators-regexp (regexp-opt miking-syn--operators 'symbols))
 
-(setq miking-syn-keywords-regexp (regexp-opt miking-syn-keywords 'symbols))
-(setq miking-syn-operators-regexp (regexp-opt miking-syn-operators 'symbols))
-(setq miking-syn-font-lock-keywords
-     `(
-       (,miking-syn-operators-regexp . font-lock-builtin-face)
-       (,miking-syn-keywords-regexp  . font-lock-keyword-face)
-       (,miking-syn-types-regexp     . font-lock-type-face)
-       )
-     )
+(defvar miking-syn-font-lock-keywords
+    `(
+         (,miking-syn--operators-regexp . font-lock-builtin-face)
+         (,miking-syn--keywords-regexp  . font-lock-keyword-face)
+         (,miking-syn--types-regexp     . font-lock-type-face)
+         )
+    "List of font lock keyword specifications to use in `miking-syn-mode'.")
 
-(defvar miking-syn-mode-syntax-table nil "Syntax table for `miking-syn-mode'.")
-
-(setq miking-syn-mode-syntax-table
-      (let ((table (make-syntax-table)))
+(defvar miking-syn-mode-syntax-table
+    (let ((table (make-syntax-table)))
         ;; Inline comment "-- ..."
         ;; Block comment "/- ... -/"
         (modify-syntax-entry ?- ". 123" table)
         (modify-syntax-entry ?/ ". 14cn" table)
         (modify-syntax-entry ?\n "> " table)
         (modify-syntax-entry ?' "\"" table)
-        table))
+        table)
+    "Syntax table for `miking-syn-mode'.")
 
 ;;;;;;;;;;;;;;;;;
 ;; compilation ;;


### PR DESCRIPTION
This PR:
1. Fixes compilation warnings and tweaks visibility/documentation of variables in `miking-syn-mode.el` to be similar to `mcore-mode.el`.
2. Shares error matching and display code between `mcore-mode` and `miking-syn-mode` as the format is identical. It also fixes a bug where the previous ANSI coloring filter interfered with the built-in filter `ansi-color-compilation-filter` in newer versions of emacs. If available we simply use the built-in filter.
3. Removes obsolete code for setting `MCORE_STDLIB` when compiling in `mcore-mode`.